### PR TITLE
Add extra info to books and bookshelves

### DIFF
--- a/public/scripts/bookloader.js
+++ b/public/scripts/bookloader.js
@@ -13,7 +13,7 @@
             if (err) return console.log(err);
             console.log(result);
             result.reverse().forEach(function(i) {
-                var owner = i.owner;
+                var owner = i.owner.name;
                 var bookshelf = i.bookshelf;
                 var title = i.title;
                 var author = i.author;

--- a/public/scripts/bookloader.js
+++ b/public/scripts/bookloader.js
@@ -14,7 +14,7 @@
             console.log(result);
             result.reverse().forEach(function(i) {
                 var owner = i.owner.name;
-                var bookshelf = i.bookshelf;
+                var bookshelf = i.bookshelf.name;
                 var title = i.title;
                 var author = i.author;
                 var description = i.description;

--- a/public/scripts/bookshelfloader.js
+++ b/public/scripts/bookshelfloader.js
@@ -12,7 +12,7 @@
             if (err) return console.log(err);
             console.log(result);
             result.reverse().forEach(function(i) {
-                var owner = i.owner;
+                var owner = i.owner.name;
                 var name = i.name;
                 var imagename = i.imagename;
                 var description = i.description;

--- a/resources/books/get.js
+++ b/resources/books/get.js
@@ -1,5 +1,6 @@
 dpd.bookshelves.get(this.bookshelf, (function(bookshelf) {
     if(bookshelf) {
+        this.bookshelf = { id: bookshelf.id, name: bookshelf.name };
         dpd.users.get(bookshelf.owner, (function(owner) {
             if(owner) {
                 this.owner = { id: owner.id, username: owner.username, name: owner.name };

--- a/resources/books/get.js
+++ b/resources/books/get.js
@@ -1,0 +1,9 @@
+dpd.bookshelves.get(this.bookshelf, (function(bookshelf) {
+    if(bookshelf) {
+        dpd.users.get(bookshelf.owner, (function(owner) {
+            if(owner) {
+                this.owner = { id: owner.id, username: owner.username, name: owner.name };
+            }
+        }).bind(this)); 
+    }
+}).bind(this));

--- a/resources/bookshelves/get.js
+++ b/resources/bookshelves/get.js
@@ -1,0 +1,5 @@
+dpd.users.get(this.owner, (function(owner) {
+    if(owner) {
+        this.owner = { id: owner.id, username: owner.username, name: owner.name };
+    }
+}).bind(this));


### PR DESCRIPTION
Use events to look up information about the user into the book and bookshelf responses. This way, the owner name is not needed as am actual property.